### PR TITLE
Fix show_buf

### DIFF
--- a/fnl/hotpot/hotterpot.fnl
+++ b/fnl/hotpot/hotterpot.fnl
@@ -57,7 +57,7 @@
     [false errors] (vim.api.nvim_err_write errors)))
 
 (fn show-buf [buf]
-  (local lines (table.concat (vim.api.nvim_buf_get_lines buf 0 -1 false)))
+  (local lines (table.concat (vim.api.nvim_buf_get_lines buf 0 -1 false) "\n"))
   (-> lines
       (compile-string {:filename :hotpot-show})
       (print-compiled)))


### PR DESCRIPTION
Fix `show_buf` function. It can't work for this simple code snippet

```clojure
;
#true
```