### PR TITLE
Exported missing eval-range

### DIFF
--- a/fnl/hotpot/api/eval.fnl
+++ b/fnl/hotpot/api/eval.fnl
@@ -74,6 +74,7 @@
     (vim.api.nvim_buf_set_lines 0 (- i 1) i false [(func (or line "") i)])))
 
 {: eval-string
+ : eval-range
  : eval-selection
  : eval-buffer
  : eval-file


### PR DESCRIPTION
`eval-range` was missing from the exported functions in `hotpot.api.eval` but was mentioned in the README, so I assumed it was intended to be exported, just like the rest of `eval-` (or `compile-`) functions.