### PR TITLE
Fix mapping in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ At it's most basic, you may simply `print` the results:
 **Evaluate and Print Selection**
 
 ```lua
-vim.api.nvim_set_keymap("v",
+vim.api.nvim_set_keymap("x",
                         "<leader>fe",
                         "<cmd>lua print(require('hotpot.api.eval')['eval-selection']())<cr>",
                         {noremap = true, silent = false})


### PR DESCRIPTION
To use selection based command we should operate on range. And it's usually done with `xnoremap` mappings.