### PR TITLE
fix: add Windows compatibility

### DIFF
--- a/fnl/hotpot/fs.fnl
+++ b/fnl/hotpot/fs.fnl
@@ -86,8 +86,12 @@
     true true
     (nil e) (values false e)))
 
-(fn normalise-path [path]
-  (vim.fs.normalize path {:expand_env false}))
+(local normalise-path (if (not= 0 (vim.fn.has :win32))
+                          (fn [path]
+                            (-?> (vim.fs.normalize path {:expand_env false})
+                                 (: :gsub "/" "\\")))
+                          (fn [path]
+                            (vim.fs.normalize path {:expand_env false}))))
 
 {: read-file!
  : write-file!

--- a/fnl/hotpot/loader/record.fnl
+++ b/fnl/hotpot/loader/record.fnl
@@ -19,11 +19,8 @@
 
 (local {:format fmt} string)
 (local {: file-exists? : file-missing? : read-file!
-        : file-stat : rm-file
+        : file-stat : rm-file : normalise-path
         : make-path : join-path : path-separator} (require :hotpot.fs))
-
-(local normalise-path (let [{: normalize} vim.fs]
-                        #(normalize $1 {:expand_env false})))
 
 (local uri-encode (or (and vim.uri_encode #(vim.uri_encode $1 :rfc2396))
                       ;; backported from nvim-0.10

--- a/fnl/hotpot/loader/record/module.fnl
+++ b/fnl/hotpot/loader/record/module.fnl
@@ -5,6 +5,7 @@
                        :lua-cache-path :lua-colocation-path
                        :namespace :modname
                        :lua-path :src-path])
+(local path-sep ((. (require :hotpot.fs) :path-separator)))
 
 (λ new [modname src-path {: prefix : extension &as opts}]
   "Examine modname and fnl path, generate lua paths, colocations, etc"
@@ -24,9 +25,17 @@
         context-dir (string.sub src-path 1 context-dir-end-position)
         code-path (string.sub src-path (+ context-dir-end-position 1))
         ;; small edgecase for relative paths such as in `VIMRUNTIME=runtime nvim`
-        namespace (case (string.match context-dir ".+/(.-)/$")
+        namespace (case (string.match context-dir (.. ".+"
+                                                      path-sep
+                                                      "(.-)"
+                                                      path-sep
+                                                      "$"))
                     namespace namespace
-                    nil (string.match context-dir "([^/]-)/$"))
+                    nil (string.match context-dir (.. "([^"
+                                                      path-sep
+                                                      "]-)"
+                                                      path-sep
+                                                      "$")))
         ;; Replace containing dir and extension
         fnl-code-path (.. prefix
                           (string.sub code-path (+ prefix-length 1) (* -1 (+ 1 extension-length)))


### PR DESCRIPTION
`vim.fn.normalize` on Windows converts all the backslashes (standard Windows path component separator) in slashes (unix style).
To fix this I convert back slashes in backslashes if `(not= 0 vim.fn.has('win32'))`.
Fix hotpot.loader.record.module to use current platform's path component separator instead of fixed slash.

Tested on Windows 11
```
NVIM v0.9.1
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
```