### PR TITLE
docs: fix preprocessor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ require("hotpot").setup({
     -- options passed to fennel.compile for macros, defaults as shown
     macros = {
       env = "_COMPILER" -- MUST be set along with any other options
-    }
+    },
+    -- A function that accepts a string of fennel source and a table of
+    -- of some information. Can be used to alter fennel code before it is
+    -- compiled.
+    preprocessor = nil
   }
-  -- A function that accepts a string of fennel source and a table of
-  -- of some information. Can be used to alter fennel code before it is
-  -- compiled.
-  preprocessor = nil
 })
 ```
 
@@ -254,15 +254,15 @@ require("hotpot").setup({
 
 <!-- panvimdoc-include-comment
 
-- `preprocessor` is a function that accepts the fennel source code as a string,
-and an table, `{: path : modname : macro?}`.
+- `compiler.preprocessor` is a function that accepts the fennel source code as a string,
+and an table, `{: path : modname : macro}`.
 
 -->
 
 <!-- panvimdoc-ignore-start -->
 
-- `preprocessor` is a function that accepts the fennel source code as a string,
-and an table, `{: path : modname : macro?}`.
+- `compiler.preprocessor` is a function that accepts the fennel source code as a string,
+and an table, `{: path : modname : macro}`.
 
 <!-- panvimdoc-ignore-end -->
 


### PR DESCRIPTION
I found these while trying to make preprocessor work. I also saw some more in the documentation.

As you can see I also changed `macro?` to `macro`, and that is because that was the value that I found by inspecting the arguments passed to the function.