### PR TITLE
Fix typo from wont to won't

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -75,7 +75,7 @@ return {
 }
 ```
 
-By default, Fennels compiler wont show an error if you try to reference unknown
+By default, Fennels compiler won't show an error if you try to reference unknown
 symbols. You may prefer to enforce a known list so your builds get "hard
 errors":
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ local neat = require('is_neat')
 neat("fennel") -- => "fennel is neat!"
 ```
 
-Hotpot will keep an internal cache of lua code, so you wont see files
+Hotpot will keep an internal cache of lua code, so you won't see files
 cluttering the `lua/` directory.
 
 <!-- panvimdoc-ignore-start -->
@@ -408,8 +408,8 @@ This behaviour exists in case a plugin ships with both code in both the `lua`
 and `fnl` directories, but the plugin author has post-processed the compiled
 lua code, or is using an incompatible fennel version, etc.
 
-In most cases, such as your config, Hotpot wont create `mod/lua/code.lua` and
-you wont run into any issues but it may encounter friction when writing a
+In most cases, such as your config, Hotpot won't create `mod/lua/code.lua` and
+you won't run into any issues but it may encounter friction when writing a
 plugin in fennel.
 
 # Quirks
@@ -417,7 +417,7 @@ plugin in fennel.
 - Hotpot will only *compile* fennel files that are found in Neovims RTP. It
 will *evaluate* files that are found in luas `package.path`. This is for safety
 purposes because it can be unclear where and when its safe to compile or
-overwrite `.lua` files. In most usage this wont occur -- files will be found in
+overwrite `.lua` files. In most usage this won't occur -- files will be found in
 the RTP first but it can occur when executing in scratch buffers with the
 [api](#api) or via [commands](#commands).
 

--- a/doc/hotpot-cookbook.txt
+++ b/doc/hotpot-cookbook.txt
@@ -73,7 +73,7 @@ project directory and must respecified in the `.hotpot.lua` file.
     }
 <
 
-By default, Fennels compiler wont show an error if you try to reference unknown
+By default, Fennels compiler won't show an error if you try to reference unknown
 symbols. You may prefer to enforce a known list so your builds get "hard
 errors"
 

--- a/doc/hotpot.txt
+++ b/doc/hotpot.txt
@@ -150,7 +150,7 @@ would any normal lua module.
     neat("fennel") -- => "fennel is neat!"
 <
 
-Hotpot will keep an internal cache of lua code, so you wont see files
+Hotpot will keep an internal cache of lua code, so you won't see files
 cluttering the `lua/` directory.
 
 You can may want to read the |hotpot-cookbook| or see more options in
@@ -371,8 +371,8 @@ This behaviour exists in case a plugin ships with both code in both the `lua`
 and `fnl` directories, but the plugin author has post-processed the compiled
 lua code, or is using an incompatible fennel version, etc.
 
-In most cases, such as your config, Hotpot wont create `mod/lua/code.lua` and
-you wont run into any issues but it may encounter friction when writing a
+In most cases, such as your config, Hotpot won't create `mod/lua/code.lua` and
+you won't run into any issues but it may encounter friction when writing a
 plugin in fennel.
 
 
@@ -382,7 +382,7 @@ plugin in fennel.
 - Hotpot will only _compile_ fennel files that are found in Neovims RTP. It
     will _evaluate_ files that are found in luas `package.path`. This is for safety
     purposes because it can be unclear where and when its safe to compile or
-    overwrite `.lua` files. In most usage this wont occur – files will be found in
+    overwrite `.lua` files. In most usage this won't occur – files will be found in
     the RTP first but it can occur when executing in scratch buffers with the
     |hotpot-api| or via |hotpot-commands|.
 

--- a/fnl/hotpot.fnl
+++ b/fnl/hotpot.fnl
@@ -6,8 +6,8 @@
       neovim-runtime (require :hotpot.neovim.runtime)
       {:auto automake} (require :hotpot.api.make)]
 
-  ;; We must ensure the rtp dir exists now otherwise vim.loader wont see
-  ;; it, and wont setup some internal mechanisms for the directory.
+  ;; We must ensure the rtp dir exists now otherwise vim.loader won't
+  ;; see it, and won't setup some internal mechanisms for the directory.
   (make-path compiled-cache-path)
   (vim.opt.runtimepath:prepend (join-path compiled-cache-path "*"))
   (tset package.loaders 1 (make-searcher))

--- a/fnl/hotpot/loader/init.fnl
+++ b/fnl/hotpot/loader/init.fnl
@@ -266,7 +266,7 @@
           ;; If the lua file was found colocated, but we did not know about it,
           ;; we should ask the user they're sure they want us to overwrite it.
           ;; If we do overwrite it, we'll then know about it in future compiles
-          ;; and wont have to ask.
+          ;; and won't have to ask.
           (case-try
             (make-module-record modname src-path) record
             (set-index-target-colocation record) record

--- a/plugin/hotpot.vim
+++ b/plugin/hotpot.vim
@@ -18,7 +18,7 @@ command! -nargs=1 -complete=file Fnlsource
 
 augroup hotpot_nvim
   autocmd!
-  " need a command so we can actually use <afile>, :lua wont expand
+  " need a command so we can actually use <afile>, :lua won't expand
   autocmd! SourceCmd *.fnl :Fnlsource <afile>:p
 augroup END
 


### PR DESCRIPTION
Fixed a typo I first noticed in the README, and then elsewhere.

_Perhaps the choice of "wont" vs "won't" was stylistic or preferred by the author, in which case please ignore!_  
